### PR TITLE
refactored tile Input

### DIFF
--- a/src/main/java/com/martyworm/Battle/Battle.java
+++ b/src/main/java/com/martyworm/Battle/Battle.java
@@ -18,6 +18,7 @@ import com.martyworm.ui.UIImageButton;
 import com.martyworm.ui.UIManager;
 
 import java.awt.Graphics;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +55,6 @@ public class Battle {
         player1 = new Player(handler, 1);
         player2 = new Player(handler, 2);
 
-
         this.entities = entityManager.getEntities();
 
 
@@ -62,6 +62,7 @@ public class Battle {
         String boardData = Board.loadBoardFile("worlds/world3.txt");
         List<Tile> tiles = Board.loadTiles(boardData);
         tileManager = new TileManager(handler, tiles);
+        handler.getController().setTileManager(tileManager);
 
         uiManager.addObject(new UIImageButton(1340, 840, 128, 64, Assets.endTurnButton, new ClickListener() {
             @Override
@@ -90,12 +91,11 @@ public class Battle {
 
 
     public void tick(){
-
-        tileManager.tick();
         uiManager.tick();
+        tileManager.tick();
+        entityManager.tick();
         player1.tick();
         player2.tick();
-        entityManager.tick();
 
     }
 
@@ -135,6 +135,13 @@ public class Battle {
     public Player getCurrentPlayer(){
         if(player1.isTurn()) return player1;
         else return player2;
+    }
+
+    public Tile getSelectedTile(){
+        if(tileManager.getSelectedTile() != null) {
+            return tileManager.getSelectedTile();
+        }
+        return null;
     }
 
     public Handler getHandler() {

--- a/src/main/java/com/martyworm/board/TileManager.java
+++ b/src/main/java/com/martyworm/board/TileManager.java
@@ -5,6 +5,7 @@ import com.martyworm.board.tiles.Tile;
 import com.martyworm.entities.Entity;
 
 import java.awt.Graphics;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class TileManager {
     public void tick(){
         for(Tile t : tiles){
             t.tick();
-            getInput(t); //this seems like a really bad idea, this class should have 1 job
+            booleansUpdate(t);
         }
     }
 
@@ -35,10 +36,8 @@ public class TileManager {
         }
     }
 
-    private void getInput(Tile t){
+    private void booleansUpdate(Tile t){
         entityBooleanInput(t);
-        mouseBooleanInput(t);
-
         //While a tile is occupied it shouldnt be semiHighlighted or selected
         if(t.isOccupied()){
             t.setSelected(false);
@@ -71,21 +70,26 @@ public class TileManager {
         }
     }
 
-    private void mouseBooleanInput(Tile t){
-
-        t.setHovering(false);
-
-        if(handler.getController().getHitBox().intersects(t.getHitBox())){ //this should be passed in
-            t.setHovering(true);
-            if(handler.getController().isLeftPressed()){
-                for(Tile y : tiles){
-                    y.setSelected(false); //this is called in a loop, then we loop again, seems wasteful
+    public void onMouseMove(MouseEvent e){
+        for(Tile t : tiles){
+            t.onMouseMove(e);
+        }
+    }
+    public void onLeftMouseRelease(MouseEvent e) {
+        for (Tile t : tiles) {
+            for (Tile y : tiles) {
+                if (y.isHovering()) {
+                    t.setSelected(false);
                 }
+            }
+            if (t.isHovering()) {
                 t.setSelected(true);
+            }
+            if (!hoveringOnTile()) {
+                t.setSelected(false);
             }
         }
     }
-
 
     private void updateSemiHiTiles(Tile t){
         if(t.isSemiHighlited() && !semiHiTiles.contains(t)){ //consider a set instead of a list to remove duplicates
@@ -98,7 +102,14 @@ public class TileManager {
         }
 
     }
-
+    private boolean hoveringOnTile(){
+        for(Tile t : tiles){
+            if(handler.getController().getHitBox().intersects(t.getHitBox())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     //Getters & Setters
     public Handler getHandler() {

--- a/src/main/java/com/martyworm/cards/Card.java
+++ b/src/main/java/com/martyworm/cards/Card.java
@@ -96,7 +96,7 @@ public class Card{
     }
 
     public void onLeftMouseRelease(MouseEvent e){
-        onClick(); //why is this here?
+        onClick();
         if(!selected || !hoveringOnRedTile()) {
             return;
         }
@@ -145,7 +145,8 @@ public class Card{
     }
 
     protected Tile selectCastingTile(){
-        return handler.getBattle().getTileManager().getSelectedTile();
+
+        return handler.getBattle().getSelectedTile();
     }
 
     protected void turnTilesRed(int playerId){}

--- a/src/main/java/com/martyworm/cards/CardManager.java
+++ b/src/main/java/com/martyworm/cards/CardManager.java
@@ -33,7 +33,7 @@ public class CardManager {
         }
 
         organizeHandForDisplay(sortAndUpdateHand());
-        organizeActiveForDisplay(sortAndUpdateActive());
+        organizeActiveForDisplay(updateActive());
 
         turnOffRedTilesWhileNoCardSelected();
     }
@@ -69,7 +69,6 @@ public class CardManager {
 
     }
 
-    //this method doesn't make any sense given it's name - what does it do?
     public ArrayList<Card> sortAndUpdateHand(){
         //Worried about hand.size()... seems to iterate and go 0, 1, 2, 2, 2, 2, 2, etc
         ArrayList<Card> hand = new ArrayList<>();
@@ -106,8 +105,7 @@ public class CardManager {
         }
     }
 
-    //this name is misleading - where is there any sorting?
-    public ArrayList<Card> sortAndUpdateActive(){
+    public ArrayList<Card> updateActive(){
 
         ArrayList<Card> active = new ArrayList<>();
 
@@ -155,7 +153,7 @@ public class CardManager {
             c.onMouseMove(e);
         }
     }
-    public void onLeftMouseReleased(MouseEvent e){
+    public void onLeftMouseRelease(MouseEvent e){
         for(Card c : cards){
             //c.setSelected(false);
             for(Card d : cards) {
@@ -176,7 +174,7 @@ public class CardManager {
 
 
     }
-    public void onRightMouseReleased(MouseEvent e){
+    public void onRightMouseRelease(MouseEvent e){
         for(Card c : cards){
             c.onRightMouseRelease(e);
         }

--- a/src/main/java/com/martyworm/entities/EntityManager.java
+++ b/src/main/java/com/martyworm/entities/EntityManager.java
@@ -32,8 +32,8 @@ public class EntityManager {
             if (e.getPlayerId() == handler.getBattle().getCurrentPlayer().getId()) {
                 if (e.isSelected()) {
 
-                    if (e.getMovesAvailable() > 0 && handler.getBattle().getTileManager().getSelectedTile() != null) {
-                        selectedTile = handler.getBattle().getTileManager().getSelectedTile();
+                    if (e.getMovesAvailable() > 0 && handler.getBattle().getSelectedTile() != null) {
+                        selectedTile = handler.getBattle().getSelectedTile();
                     }
                     showAvailableMoves(e);
                     showPathFinder(e);

--- a/src/main/java/com/martyworm/gui/MouseController.java
+++ b/src/main/java/com/martyworm/gui/MouseController.java
@@ -6,6 +6,7 @@ import java.awt.event.MouseEvent;
 import javax.swing.event.MouseInputListener;
 
 
+import com.martyworm.board.TileManager;
 import com.martyworm.cards.CardManager;
 import com.martyworm.ui.UIManager;
 
@@ -16,6 +17,7 @@ public class MouseController implements MouseInputListener{
     private int mouseX, mouseY;
     private CardManager cardManager;
     private UIManager uiManager;
+    private TileManager tileManager;
     private Rectangle hitBox;
 
     public MouseController(){
@@ -31,6 +33,9 @@ public class MouseController implements MouseInputListener{
         this.cardManager = cardManager;
     }
 
+    public void setTileManager(TileManager tileManager){
+        this.tileManager = tileManager;
+    }
 
     @Override
     public void mousePressed(MouseEvent e) {
@@ -43,16 +48,26 @@ public class MouseController implements MouseInputListener{
 
         if(e.getButton() == MouseEvent.BUTTON1) {
             leftPressed = false;
+
+            //The following two calls must be in this order if the cardManager is to interact with the board
+            if(tileManager != null){
+                tileManager.onLeftMouseRelease(e);
+            }
+            if(cardManager != null){
+                cardManager.onLeftMouseRelease(e);
+            }
+
         }
         if(e.getButton() == MouseEvent.BUTTON3){
             rightPressed = false;
+            if(cardManager != null){
+                cardManager.onRightMouseRelease(e);
+            }
         }
         if(uiManager != null){
             uiManager.onMouseRelease(e);
         }
-        if(cardManager != null){
-            cardManager.onLeftMouseReleased(e);
-        }
+
 
     }
 
@@ -65,12 +80,17 @@ public class MouseController implements MouseInputListener{
         hitBox.x = mouseX;
         hitBox.y = mouseY;
 
+        //These three calls must be in this order
         if(uiManager != null){
             uiManager.onMouseMove(e);
+        }
+        if(tileManager != null) {
+            tileManager.onMouseMove(e);
         }
         if(cardManager != null) {
             cardManager.onMouseMove(e);
         }
+
     }
 
 


### PR DESCRIPTION
refactored tileManagers input system to be called from the MouseController

Also when you asked "why is this here?" in regards to the onClick call in Card class, the Override for onClick ends at the individual cards (CardRedDragon) and (CardSkeleton) where the tiles are turned red.

One new bug to report in this branch is that the minion's movement, after the first initial movement, requires two clicks for some reason.  I suspect once the entityManager's input system is refactored in the same way as the tileManager, then the issue will be resolved.  Until then I'm not digging too deep into it.